### PR TITLE
add support for custom time zone

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -18,7 +18,7 @@ LABEL eu.biggis-project.build-date=$BUILD_DATE \
       eu.biggis-project.version=$ALPINE_VERSION
 
 ADD repositories /etc/apk/
-RUN apk add --no-cache gosu@testing && \
+RUN apk add --no-cache gosu@testing tzdata && \
     mkdir /storage /opt
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -7,6 +7,15 @@
 USER_ID=${USER_ID:-9001}
 USER=${USER_NAME:-biggis}
 
+# Set the timezone. Base image does not contain the setup-timezone script, so an alternate way is used.
+if [ -n "$TIMEZONE" ]; then
+    cp /usr/share/zoneinfo/${TIMEZONE} /etc/localtime && \
+	echo "${TIMEZONE}" >  /etc/timezone && \
+	echo "Container timezone set to: $TIMEZONE"
+else
+	echo "Container timezone not modified"
+fi
+
 echo "Starting with UID : $USER_ID"
 addgroup -S -g $USER_ID $USER
 adduser -h /home/$USER -u $USER_ID -s /bin/sh -G $USER -S $USER

--- a/java8-jre/Dockerfile
+++ b/java8-jre/Dockerfile
@@ -18,7 +18,7 @@ LABEL eu.biggis-project.build-date=$BUILD_DATE \
       eu.biggis-project.version=$JRE_VERSION
 
 ADD repositories /etc/apk
-RUN apk add --no-cache bash gosu@testing
+RUN apk add --no-cache bash gosu@testing tzdata
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/java8-jre/entrypoint.sh
+++ b/java8-jre/entrypoint.sh
@@ -7,6 +7,15 @@
 USER_ID=${USER_ID:-9001}
 USER=${USER_NAME:-biggis}
 
+# Set the timezone. Base image does not contain the setup-timezone script, so an alternate way is used.
+if [ -n "$TIMEZONE" ]; then
+    cp /usr/share/zoneinfo/${TIMEZONE} /etc/localtime && \
+	echo "${TIMEZONE}" >  /etc/timezone && \
+	echo "Container timezone set to: $TIMEZONE"
+else
+	echo "Container timezone not modified"
+fi
+
 echo "Starting with UID : $USER_ID"
 addgroup -S -g $USER_ID $USER
 adduser -h /home/$USER -u $USER_ID -s /bin/bash -G $USER -S $USER

--- a/oraclejava/Dockerfile
+++ b/oraclejava/Dockerfile
@@ -18,7 +18,7 @@ LABEL eu.biggis-project.build-date=$BUILD_DATE \
       eu.biggis-project.version=$ORACLEJAVA
 
 ADD repositories /etc/apk
-RUN apk add --no-cache bash gosu@testing
+RUN apk add --no-cache bash gosu@testing tzdata
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/oraclejava/entrypoint.sh
+++ b/oraclejava/entrypoint.sh
@@ -7,6 +7,15 @@
 USER_ID=${USER_ID:-9001}
 USER=${USER_NAME:-biggis}
 
+# Set the timezone. Base image does not contain the setup-timezone script, so an alternate way is used.
+if [ -n "$TIMEZONE" ]; then
+    cp /usr/share/zoneinfo/${TIMEZONE} /etc/localtime && \
+	echo "${TIMEZONE}" >  /etc/timezone && \
+	echo "Container timezone set to: $TIMEZONE"
+else
+	echo "Container timezone not modified"
+fi
+
 echo "Starting with UID : $USER_ID"
 addgroup -S -g $USER_ID $USER
 adduser -h /home/$USER -u $USER_ID -s /bin/bash -G $USER -S $USER


### PR DESCRIPTION
This pull request enables containers using other time zones than UTC by setting the environment variable `TIMEZONE`.

**alpine**
```
$ docker run -it --rm biggis/base:alpine date
Container timezone not modified
Starting with UID : 9001
Sat Apr  8 09:12:25 UTC 2017

$ docker run -it --rm -e TIMEZONE=Europe/Berlin biggis/base:alpine date
Container timezone set to: Europe/Berlin
Starting with UID : 9001
Sat Apr  8 11:12:16 CEST 2017
```
**java8-jre**
```
$ docker run -it --rm biggis/base:java8-jre date
Container timezone not modified
Starting with UID : 9001
Sat Apr  8 09:15:50 UTC 2017

$ docker run -it --rm -e TIMEZONE=Europe/Berlin biggis/base:java8-jre date
Container timezone set to: Europe/Berlin
Starting with UID : 9001
Sat Apr  8 11:16:05 CEST 2017
```

**oraclejava**
```
$ docker run -it --rm biggis/base:oraclejava date
Container timezone not modified
Starting with UID : 9001
Sat Apr  8 09:21:43 UTC 2017

$ docker run -it --rm -e TIMEZONE=Europe/Berlin biggis/base:oraclejava date
Container timezone set to: Europe/Berlin
Starting with UID : 9001
Sat Apr  8 11:21:37 CEST 2017
```